### PR TITLE
Support es7

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,19 @@
 composer require flc/laravel-elasticsearch
 ```
 
+## 说明
+
+v1.2.0 版本开始仅支持 Elasticsearch 7.x 版本，扩展依赖 elasticsearch/elasticsearch ^7.0 ，如使用 Elasticsearch 6.x 请使用 v1.1.0 版本。 
+
+## 版本矩阵
+
+
+| Elasticsearch Version | Elasticsearch-PHP Branch |
+| --------------------- |--------------------------|
+| >= 7.x                | >= 7.x                   |
+
+
+
 ## 配置
 
 [使用文档](https://docs.flc.io/elasticsearch/laravel-elasticsearch/introduction/)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ composer require flc/laravel-elasticsearch
 
 ## 说明
 
-v1.2.0 版本开始仅支持 Elasticsearch 7.x 版本，扩展依赖 elasticsearch/elasticsearch ^7.0 ，如使用 Elasticsearch 6.x 请使用 v1.1.0 版本。 
+v2.0.0 版本开始仅支持 Elasticsearch 7.x 版本，扩展依赖 elasticsearch/elasticsearch ^7.0 ，如使用 Elasticsearch 6.x 请使用 v1.1.0 版本。 
 
 ## 版本矩阵
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,19 @@
 composer require flc/laravel-elasticsearch
 ```
 
+## 说明
+
+V1.2.0 版本开始仅支持 Elasticsearch 7.x 版本，扩展依赖 elasticsearch/elasticsearch ^7.0 ，如使用 Elasticsearch 6.x 请使用 v1.1.0 版本。 
+
+## 版本矩阵
+
+
+| Elasticsearch Version | Elasticsearch-PHP Branch |
+| --------------------- |--------------------------|
+| >= 7.x                | >= 7.x                   |
+
+
+
 ## 配置
 
 [使用文档](https://docs.flc.io/elasticsearch/laravel-elasticsearch/introduction/)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ composer require flc/laravel-elasticsearch
 
 ## 说明
 
-V1.2.0 版本开始仅支持 Elasticsearch 7.x 版本，扩展依赖 elasticsearch/elasticsearch ^7.0 ，如使用 Elasticsearch 6.x 请使用 v1.1.0 版本。 
+v1.2.0 版本开始仅支持 Elasticsearch 7.x 版本，扩展依赖 elasticsearch/elasticsearch ^7.0 ，如使用 Elasticsearch 6.x 请使用 v1.1.0 版本。 
 
 ## 版本矩阵
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.3|^8.0",
-        "elasticsearch/elasticsearch": "^6.0|^7.0"
+        "elasticsearch/elasticsearch": "^7.0"
     },
     "require-dev": {
         "laravel/framework": "^5.0|^6.0|^7.0|^8.0|^9.0|^10.0",

--- a/src/Collections/SearchCollection.php
+++ b/src/Collections/SearchCollection.php
@@ -31,7 +31,7 @@ class SearchCollection
      */
     public function total(): int
     {
-        return $this->result['hits']['total'] ?? 0;
+        return $this->result['hits']['total']['value'] ?? 0;
     }
 
     /**

--- a/src/Collections/SearchCollection.php
+++ b/src/Collections/SearchCollection.php
@@ -35,7 +35,7 @@ class SearchCollection
     }
 
     /**
-     * 返回总记录数
+     * 返回总记录数信息
      *
      * @return array
      */

--- a/src/Collections/SearchCollection.php
+++ b/src/Collections/SearchCollection.php
@@ -35,6 +35,16 @@ class SearchCollection
     }
 
     /**
+     * 返回总记录数
+     *
+     * @return array
+     */
+    public function totalObj(): array
+    {
+        return $this->result['hits']['total'];
+    }
+
+    /**
      * 返回 source 集合
      *
      * @return \Illuminate\Support\Collection

--- a/src/Concerns/BuildsQueries.php
+++ b/src/Concerns/BuildsQueries.php
@@ -19,7 +19,7 @@ trait BuildsQueries
      *
      * @param array $result
      *
-     * @return \Flc\Laravel\Elasticsearch\Collections\SearchCollection
+     * @return SearchCollection
      */
     protected function searchCollection(array $result = []): SearchCollection
     {

--- a/src/ElasticsearchConnection.php
+++ b/src/ElasticsearchConnection.php
@@ -2,9 +2,9 @@
 
 namespace Flc\Laravel\Elasticsearch;
 
+use Elasticsearch\Client as ElasticsearchClient;
 use Flc\Laravel\Elasticsearch\Query\Builder;
 use Flc\Laravel\Elasticsearch\Query\Grammar;
-use Elasticsearch\Client as ElasticsearchClient;
 
 /**
  * Elasticsearch 连接
@@ -31,7 +31,7 @@ class ElasticsearchConnection
      */
     public function __construct(ElasticsearchClient $client, Grammar $grammar)
     {
-        $this->client = $client;
+        $this->client  = $client;
         $this->grammar = $grammar;
     }
 
@@ -54,7 +54,7 @@ class ElasticsearchConnection
     /**
      * 调用构建类
      *
-     * @return \Flc\Laravel\Elasticsearch\Query\Builder
+     * @return Builder
      */
     public function builder(): Builder
     {
@@ -67,7 +67,7 @@ class ElasticsearchConnection
      * Dynamically pass methods to the default connection.
      *
      * @param string $method
-     * @param array $parameters
+     * @param array  $parameters
      *
      * @return mixed
      */

--- a/src/ElasticsearchManager.php
+++ b/src/ElasticsearchManager.php
@@ -41,7 +41,7 @@ class ElasticsearchManager
      *
      * @param string|null $name
      *
-     * @return \Flc\Laravel\Elasticsearch\ElasticsearchConnection
+     * @return ElasticsearchConnection
      */
     public function connection($name = null): ElasticsearchConnection
     {
@@ -101,7 +101,7 @@ class ElasticsearchManager
      *
      * @param array $config
      *
-     * @return \Flc\Laravel\Elasticsearch\ElasticsearchConnection
+     * @return ElasticsearchConnection
      */
     protected function makeConnection(array $config): ElasticsearchConnection
     {

--- a/src/ElasticsearchServiceProvider.php
+++ b/src/ElasticsearchServiceProvider.php
@@ -2,9 +2,9 @@
 
 namespace Flc\Laravel\Elasticsearch;
 
+use Illuminate\Foundation\Application as LaravelApplication;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Lumen\Application as LumenApplication;
-use Illuminate\Foundation\Application as LaravelApplication;
 
 /**
  * Elasticsearch 服务者

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -16,12 +16,12 @@ class Builder
     use BuildsQueries;
 
     /**
-     * @var \Elasticsearch\Client
+     * @var ElasticsearchClient
      */
     public $client;
 
     /**
-     * @var \Flc\Laravel\Elasticsearch\Query\Grammar
+     * @var Grammar
      */
     public $grammar;
 
@@ -38,6 +38,13 @@ class Builder
      * @var string
      */
     public $type;
+
+    /**
+     * 是否返回实际命中的文档数
+     *
+     * @var bool
+     */
+    public $trackTotalHits = true;
 
     /**
      * 搜寻条件
@@ -117,6 +124,22 @@ class Builder
     public function index(string $value): Builder
     {
         $this->index = $value;
+
+        return $this;
+    }
+
+    /**
+     * 关闭返回实际命中的文档数
+     *
+     * @note 如使用该方法，当结果文档数超过 10000 时，
+     * 注意返回的结果中的 total 字段将不再返回实际命中的文档数，
+     * 最大返回 10000
+     *
+     * @return $this
+     */
+    public function disableTrackTotalHits(): Builder
+    {
+        $this->trackTotalHits = false;
 
         return $this;
     }
@@ -250,7 +273,7 @@ class Builder
     /**
      * 返回新的构建类
      *
-     * @return \Flc\Laravel\Elasticsearch\Query\Builder
+     * @return Builder
      */
     public function newQuery(): Builder
     {

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -129,17 +129,17 @@ class Builder
     }
 
     /**
-     * 关闭返回实际命中的文档数
+     * 是否返回实际命中的文档数
      *
-     * @note 如使用该方法，当结果文档数超过 10000 时，
-     * 注意返回的结果中的 total 字段将不再返回实际命中的文档数，
-     * 最大返回 10000
+     * @param bool $value 是否返回实际文档数，true-返回实际命中的文档数，false-不返回实际命中的文档数
+     *
+     * @note 如设置 false ，当结果文档数超过 10000 时，返回的结果中的 total 字段将不再返回实际命中的文档数，最大返回 10000
      *
      * @return $this
      */
-    public function disableTrackTotalHits(): Builder
+    public function trackTotalHits(bool $value = true): Builder
     {
-        $this->trackTotalHits = false;
+        $this->trackTotalHits = $value;
 
         return $this;
     }

--- a/src/Query/Grammar.php
+++ b/src/Query/Grammar.php
@@ -20,7 +20,7 @@ class Grammar
     {
         $params = $this->compileBase($query);
 
-        // 搜索返回实际命中的文档数
+        // 搜索是否返回实际命中的文档数
         if (! empty($query->trackTotalHits)) {
             $params['track_total_hits'] = true;
         }

--- a/src/Query/Grammar.php
+++ b/src/Query/Grammar.php
@@ -20,6 +20,9 @@ class Grammar
     {
         $params = $this->compileBase($query);
 
+        // 搜索返回实际命中的文档数
+        $params['track_total_hits'] = true;
+
         if (! is_null($query->_source)) {
             $params['_source'] = $query->_source;
         }

--- a/src/Query/Grammar.php
+++ b/src/Query/Grammar.php
@@ -21,7 +21,9 @@ class Grammar
         $params = $this->compileBase($query);
 
         // 搜索返回实际命中的文档数
-        $params['track_total_hits'] = true;
+        if (! empty($query->trackTotalHits)) {
+            $params['track_total_hits'] = true;
+        }
 
         if (! is_null($query->_source)) {
             $params['_source'] = $query->_source;


### PR DESCRIPTION
申请增加es7版本支持
1. es7后，搜索结果返回的hits.total变为对象，需要hits.total.value才能实际获取文档数
2. es7后，如不设置 `'track_total_hits' => true` ，当文档数超过10000时，`hits.total.value` 只会返回 10000 , `hits.total.relation`  为 gte 